### PR TITLE
Add user's ability to like post

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!
+  include ActionView::RecordIdentifier
+
   def index
     @post = Post.new
     @posts = Post.all.order(created_at: :desc)
@@ -12,13 +14,28 @@ class PostsController < ApplicationController
         format.html { redirect_to root_path }
       else
         format.turbo_stream
-
         format.html do
           flash[:post_errors] = @post.errors.full_messages
           redirect_to root_path
         end
       end
     end
+  end
+
+  def toggle_like
+    @post = Post.find(params[:id])
+    @post.toggle_like!(user: current_user)
+    respond_to do |format|
+      format.html
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          "#{dom_id(@post)}_likes",
+          partial: "posts/likes",
+          locals: { post: @post, user: current_user }
+        )
+      end
+    end
+
   end
 
   private

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,9 @@
 module PostsHelper
+  def like_text(post, user)
+    if post.liked_by?(user:)
+      "Unlike!"
+    else
+      "Like!"
+    end
+  end
 end

--- a/app/models/concerns/voteable.rb
+++ b/app/models/concerns/voteable.rb
@@ -1,0 +1,32 @@
+module Voteable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :likes, class_name: :Vote, as: :voteable, dependent: :destroy, inverse_of: :voteable
+  end
+
+  def vote_up!(user:)
+    like = likes.find_or_create_by(user:)
+    like.liked!
+  end
+  alias like! vote_up!
+
+  def vote_down!(user:)
+    likes.find_by(user:)&.unliked!
+  end
+  alias dislike! vote_down!
+
+  def liked_by?(user:)
+    likes.where(state: :liked, user:).any?
+  end
+
+  def toggle_like!(user:)
+    if likes.where(state: :liked, user:).any?
+      vote_down!(user:)
+    else
+      vote_up!(user:)
+    end
+  end
+
+
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  include Voteable
+
   belongs_to :user
   has_rich_text :body
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,0 +1,32 @@
+class Vote < ApplicationRecord
+  belongs_to :user
+  belongs_to :voteable, polymorphic: true
+
+  enum state: {
+    liked: 0,
+    unliked: 1
+  }
+end
+
+# == Schema Information
+#
+# Table name: votes
+#
+#  id            :bigint           not null, primary key
+#  state         :integer          default("liked")
+#  voteable_type :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :bigint           not null
+#  voteable_id   :bigint           not null
+#
+# Indexes
+#
+#  index_votes_on_user_id                                    (user_id)
+#  index_votes_on_user_id_and_voteable_id_and_voteable_type  (user_id,voteable_id,voteable_type) UNIQUE
+#  index_votes_on_voteable                                   (voteable_type,voteable_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/views/posts/_likes.html.erb
+++ b/app/views/posts/_likes.html.erb
@@ -1,0 +1,10 @@
+<%= turbo_frame_tag "#{dom_id(post)}_likes" do %>
+
+  <div class="pointer-events-auto relative inline-flex rounded-md bg-white text-[0.8125rem] font-medium leading-5 text-slate-700 shadow-sm ring-1 ring-slate-700/10 hover:bg-slate-50 hover:text-slate-900">
+    <%= button_to like_text(post, user),
+      like_post_path(post),
+      method: :patch, data: { turbo_frame: '_top', }, class: "flex py-2 px-3"
+    %>
+    <div class="border-l border-slate-400/20 py-2 px-2.5"><%= post.likes.liked.count %></div>
+  </div>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,5 +5,6 @@
   </div>
   <div class="text-gray-700">
     <%= post.body %>
+    <%= render partial: 'posts/likes', locals: { post: post, user: local_assigns[:user] } %>
   </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,5 +4,5 @@
 
 <%= turbo_stream_from "posts" %>
 <%= turbo_frame_tag "posts" do %>
-  <%= render @posts %>
+<%= render @posts, user: current_user %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :posts, except: :index
+  resources :posts, except: :index do
+    member do
+      patch :like, to: 'posts#toggle_like'
+    end
+  end
   root "posts#index"
 end

--- a/db/migrate/20230211093546_create_votes.rb
+++ b/db/migrate/20230211093546_create_votes.rb
@@ -1,0 +1,13 @@
+class CreateVotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :votes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :voteable, polymorphic: true, null: false
+      t.integer :state, default: 0
+
+      t.timestamps
+    end
+
+    add_index(:votes, [:user_id, :voteable_id, :voteable_type], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_07_171737) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_11_093546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,7 +71,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_171737) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "votes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "voteable_type", null: false
+    t.bigint "voteable_id", null: false
+    t.integer "state", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "voteable_id", "voteable_type"], name: "index_votes_on_user_id_and_voteable_id_and_voteable_type", unique: true
+    t.index ["user_id"], name: "index_votes_on_user_id"
+    t.index ["voteable_type", "voteable_id"], name: "index_votes_on_voteable"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "posts", "users"
+  add_foreign_key "votes", "users"
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post do
+    body { "Test post" }
+    user
+  end
+end

--- a/spec/models/concerns/voteable_spec.rb
+++ b/spec/models/concerns/voteable_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+require "support/shoulda_matchers"
+
+shared_examples "voteable" do
+  it { is_expected.to have_many(:likes) }
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,13 +1,35 @@
 require "rails_helper"
 require "support/shoulda_matchers"
+require "models/concerns/voteable_spec"
 
 RSpec.describe Post do
   describe "associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to have_rich_text(:body) }
+    it_behaves_like "voteable"
   end
 
   describe "validations" do
     it { is_expected.to validate_presence_of :body }
+  end
+
+  describe "#toggle_like!" do
+    let(:user) { create(:user) }
+    let(:post) { create(:post, user: user) }
+
+    context "when called for the first time" do
+      it "liked the post" do
+        post.toggle_like!(user: user)
+        expect(post.likes.liked.count).to be(1)
+      end
+    end
+
+    context "when called for the second time" do
+      it "disliked the post" do
+        post.toggle_like!(user: user)
+        post.toggle_like!(user: user)
+        expect(post.likes.unliked.count).to be(1)
+      end
+    end
   end
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+require "support/shoulda_matchers"
+
+RSpec.describe Vote, type: :model do
+  it { is_expected.to have_db_column(:voteable_id).of_type(:integer) }
+  it { is_expected.to have_db_column(:voteable_type).of_type(:string) }
+
+  it { is_expected.to belong_to(:voteable) }
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -52,4 +52,18 @@ RSpec.describe "Posts requests" do
       end
     end
   end
+
+  describe "PATCH /posts#like" do
+    let(:post) { create(:post, user: user) }
+    let(:req) { patch like_post_path(post) }
+
+    it_behaves_like "an authenticated route"
+    context "with a user logged in" do
+      include_context "with user logged in"
+
+      it "creates a Vote that belongs to the liked post", :aggregate_failures do
+        expect { req }.to change(post.likes, :count).by 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Feature details

_User Facing_
* Adds the ability for a user to like a post


# Improvement
 - Move the controller functionality of liking a post to a concern so that if in the future we also want to start liking comments we wouldn't need to build a new functionality
 - Extract the likes partial to a new folder
 - Keep tabs on how many times a user likes and unlike a post for historical or  other reasons
 - A better design for the like button
 
# Testing
 - Add more tests to test out the different states of a liked and unlike post

