### PR TITLE
Dragon Drop 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,4 +94,6 @@ group :test do
 
   # Simple one-liner tests for common Rails functionality (https://matchers.shoulda.io/)
   gem "shoulda-matchers", "~> 5.0"
+
+  gem "faker"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.1.1)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -285,6 +287,7 @@ DEPENDENCIES
   debug
   devise (~> 4.8)
   factory_bot_rails
+  faker
   image_processing (~> 1.2)
   importmap-rails
   pg (~> 1.1)

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,20 @@
+class LikesController < ApplicationController
+  def create
+    @user_id = current_user.id
+    @post_id = params[:post_id]
+
+    @like = Like.new(
+      user_id: @user_id,
+      post_id: @post_id
+    )
+    @like.save unless Like.find_by(user_id: @user_id, post_id: @post_id)
+    redirect_back_or_to root_path
+  end
+
+  def destroy
+    @post = Post.find(params[:post_id])
+    @like = @post.likes.find_by(user_id: current_user.id)
+    @like.destroy if @like
+    redirect_back_or_to root_path
+  end
+end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,24 @@
+class Like < ApplicationRecord
+  belongs_to :post
+end
+
+# == Schema Information
+#
+# Table name: likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  post_id    :bigint
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_likes_on_post_id  (post_id)
+#  index_likes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (post_id => posts.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_rich_text :body
-
+  has_many :likes
   validates :body, presence: true
 
   after_create_commit { broadcast_prepend_to "posts" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
-
+  has_many :likes
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -6,4 +6,15 @@
   <div class="text-gray-700">
     <%= post.body %>
   </div>
+  <br>
+  <b>Likes: </b> <%= " #{post.likes.count}" %>
+
+  <div class="border-t border-gray-100 px-2 py-2 flex">
+    <%= button_to "Like", { :controller => :likes, :action => :create, :post_id => post.id, method: :post },
+                            { class: "bg-black text-white py-2 px-4 rounded ml-auto" } %>
+    &nbsp;
+    <%= button_to "Unlike", { :controller => :likes, :action => :destroy, :post_id => post.id, method: :post },
+                            { class: "bg-black text-white py-2 px-4 rounded ml-auto" } %>
+  </div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   resources :posts, except: :index
   root "posts#index"
+
+  post 'like', to: 'likes#create'
+  post 'dislike', to: 'likes#destroy'
 end

--- a/db/migrate/20230213073017_create_likes.rb
+++ b/db/migrate/20230213073017_create_likes.rb
@@ -1,0 +1,8 @@
+class CreateLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likes do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230213073719_add_attributes_to_like.rb
+++ b/db/migrate/20230213073719_add_attributes_to_like.rb
@@ -1,0 +1,6 @@
+class AddAttributesToLike < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :likes, :user, foreign_key: true
+    add_reference :likes, :post, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_07_171737) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_13_073719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_171737) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -73,5 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_171737) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :like do
+    association :post
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post do
+    association :user
+    body {'Hello world!'}
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user do
-    email { "email@example.com" }
+    email { Faker::Internet.email }
     password { "password" }
+    password_confirmation { "password" }
   end
 end

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LikesHelper. For example:
+#
+# describe LikesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LikesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Like, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before(:all) do
+    @post_a = create(:post)
+    @like = create(:like)
+  end
+
+  it 'New post should have zero Likes' do
+    expect(@post_a.likes.count).to equal 0
+  end
+
+  it "A New Like increases the Post's like-count by 1" do
+    @mini_post = @like.post
+    expect(@mini_post.likes.count).to eq 1
+  end
 end

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Likes", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Hi John and Adam,

Managed to get a working demo of the feature and some very basic tests added. Users can `like` posts (including their own) once and they can cancel the `like` with the `unlike` button.

# Problems

- Main issue was displaying of the `like` and `unlike` buttons depending on Devise methods in the view. I was seeing an error relating to `Warden::Proxy`.  I did try looking at fixing but it seemed too complex for me at the moment; I need to improve my understanding of Rails 7.

# Improvements

- Only show `like` and `unlike` buttons when required.
- Make use of Turbo frames so Like-info is updated without a page-refresh.
- After a user has liked a post the `like` button should be deactivated (to prevent requests to the controller) or hidden.
- After a user has unliked a post the `unlike` button should be deactivated (to prevent requests to the controller) or hidden.
- Add ability for users to follow each other. 
- Add more meaningful testing.

I look forward to hearing back from you. Many thanks.

Kind regards

Sagar