### PR TITLE
Add the ability to 'Like' posts (candidate test)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "donjayamanne.githistory"
+    ]
+}

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,28 @@
+class LikesController < ApplicationController 
+    before_action :authenticate_user!
+    before_action :get_post
+
+    def create
+        if user_signed_in?
+            @like = Like.new(user_id: current_user.id, post_id: @post.id)
+            @like.save
+            redirect_to root_path
+        else
+            redirect_to root_path
+        end
+    end
+
+
+    def destroy
+        @like = Like.find(params[:id])
+        @like.destroy
+
+        redirect_to root_path
+    end
+
+    private
+
+    def get_post
+        @post = Post.find(params[:post_id])
+    end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,6 +9,7 @@ class PostsController < ApplicationController
     @post = Post.new(post_params.merge(user: current_user))
     respond_to do |format|
       if @post.save
+        @post.broadcast_prepend_to "posts", locals: { user: current_user }
         format.html { redirect_to root_path }
       else
         format.turbo_stream

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,17 @@
+class Like < ApplicationRecord
+    belongs_to :user
+    belongs_to :post
+
+    validates :user_id, uniqueness: {scope: :post_id}
+end
+  
+# == Schema Information
+#
+# Table name: likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  post_id    :integer
+#  user_id    :integer
+#

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -2,7 +2,12 @@ class Like < ApplicationRecord
     belongs_to :user
     belongs_to :post
 
-    validates :user_id, uniqueness: {scope: :post_id}
+    validates_uniqueness_of :user_id, scope: :post_id
+    validate :user_cannot_be_post_owner
+
+    def user_cannot_be_post_owner
+      errors.add(:user, "Cannot like their own post") if user_id == Post.find(post_id).user_id
+    end
 end
   
 # == Schema Information

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :likes, dependent: :destroy
   has_rich_text :body
 
   validates :body, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,7 +5,13 @@ class Post < ApplicationRecord
 
   validates :body, presence: true
 
-  after_create_commit { broadcast_prepend_to "posts" }
+  # Moved to controller (might be a terrible idea) in order to pass devise variables 
+  # through to the newly rendered partial
+  # after_create_commit { broadcast_prepend_to "posts" }
+
+  def has_user_liked?(user)
+    user.likes.pluck(:post_id).include?(id)
+  end
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -6,4 +6,17 @@
   <div class="text-gray-700">
     <%= post.body %>
   </div>
+
+  <div class="text-red-800"> Like Count: <%= post.likes.count %></div>
+
+  <div>
+    <% if post.user.id != user.id %>
+      <% if post.has_user_liked?(user) %>
+        <% @like = Like.find_by(post: post, user: user) %>
+        <%= button_to "Un-Like", post_like_path(post, @like.id), action: "destroy", method: :delete, class: "bg-purple-500 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded"%>
+      <% else %>
+        <%= button_to "Like", post_likes_path(post), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+      <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag "post_form" do %>
-<%= render "form", post: @post %>
+  <%= render "form", post: @post %>
 <% end %>
 
 <%= turbo_stream_from "posts" %>
 <%= turbo_frame_tag "posts" do %>
-  <%= render @posts %>
+  <%= render partial: "post", collection: @posts, locals: {user: current_user} %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :posts, except: :index
+  resources :posts, except: :index do 
+    resources :likes, only: [:create, :destroy]
+  end
+
   root "posts#index"
 end

--- a/db/migrate/20230228072732_create_likes.rb
+++ b/db/migrate/20230228072732_create_likes.rb
@@ -1,0 +1,9 @@
+class CreateLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likes do |t|
+      t.integer :user_id
+      t.integer :post_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_07_171737) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_28_072732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_171737) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "likes", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "posts", force: :cascade do |t|

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require "support/shoulda_matchers"
+
+RSpec.describe Like do
+  describe "validations" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:post) { Post.create(user: user, body: "Hello!") }
+    let(:user_2) { User.create(email: "test@abc.com", password: "123456") }
+
+    it "should not be possible for a User to like their own post" do
+      like = Like.create(user: user, post: post)
+
+      expect(like).to_not be_valid
+    end
+
+    it "should not be possible for a User to like a post twice" do
+      like = Like.create(user: user_2, post: post)
+      like_2 = Like.create(user: user_2, post: post)
+
+      expect(like).to be_valid
+      expect(like_2).to_not be_valid
+    end
+  end
+end

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+require "support/shared/request_contexts"
+require "support/shared/request_specs"
+
+RSpec.describe "Posts requests" do
+  describe "GET /" do
+    let(:req) { get root_url }
+
+    it_behaves_like "an authenticated route"
+    context "with a user logged in" do
+      include_context "with user logged in"
+      include_examples "a successful response"
+    end
+  end
+
+  describe "POST /posts/:id/likes" do
+    let(:new_user) { User.create(email: "test@abc.com", password: "123456") }
+    let(:new_post) { Post.create(user: new_user, body: "Hello!") }
+    let(:req) { post "/posts/#{new_post.id}/likes", params: { post_id: new_post.id } }
+
+    it_behaves_like "an authenticated route"
+
+    context "with a user logged in" do
+      include_context "with user logged in"
+
+      context "with valid params" do
+        it "creates a Like for the given post that belongs to the logged in user" do
+          expect { req }.to change(Like, :count).by 1
+          expect(Like.last.user).to eq user
+        end
+
+        it "redirects to the root path" do
+          req
+
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This PR enables users to like each others posts on the microblog. The basic functionality is as follows:** 

- Users are presented with a new, 'Like' button under each post in the index view.
- Clicking this creates a Like (this is a new model in the app), linked to both User and Post. 
- Once 'Liked', a post cannot be liked again - but it can be 'Unliked' which will delete the Like 
  record and enable Liking again.
- The total number of likes a Post has is displayed in the index view. (Screenshot of functionality below)

Things I'd like to add with more time:
- Ability to see _which_ users have liked your post 
- Turbo-fication of the like system - wrapping each post in a turbo frame and updating the UI with these, 
  rather than the more traditional rails logic it uses at the moment of routing to the index. 
- Investigate the clash between Turbo and Devise further. I explain this a bit in the commit messages, but 
  having not worked with Turbo before and given the time constraints, I prioritized getting a working version over
  really understanding what's happening here. 
- More expansive tests and factories, just across the board really. 
- A nice UI with icons for likes. 

Please let me know if you have questions or feedback on any of this! 

![Microblog Likes](https://user-images.githubusercontent.com/43963734/221842733-e478bc5a-7f5f-49ef-8725-e0fcc78e2406.png)
